### PR TITLE
JW-810_report_log_file_error

### DIFF
--- a/src/vnsw/agent/contrail/main.cc
+++ b/src/vnsw/agent/contrail/main.cc
@@ -85,8 +85,8 @@ int main(int argc, char *argv[]) {
         init_file = var_map["config_file"].as<string>();
         struct stat s;
         if (stat(init_file.c_str(), &s) != 0) {
-            LOG(ERROR, "Error opening config file <" << init_file 
-                << ">. Error number <" << errno << ">");
+            cout << "Error opening config file <" << init_file
+                << ">. Error number <" << errno << ">";
             exit(EINVAL);
         }
     }


### PR DESCRIPTION
Invoking LOG macro here can not succeed because log file is initialized later in the code. Log file name is retrieved from the configuration file, so it seems that the most reasonable solution is to print an error to cout (cout is used for other messages in the same function).