### PR TITLE
JW-914: Fix ifmap test, disable unnecessary DNS bind test

### DIFF
--- a/src/dns/test/dns_bind_test.cc
+++ b/src/dns/test/dns_bind_test.cc
@@ -231,7 +231,8 @@ TEST_F(DnsBindTest, Config) {
 }
 #endif
 
-TEST_F(DnsBindTest, Reordered) {
+// TODO(WINDOWS): JW-1168: NamedConfig is not used in the Agent
+TEST_F(DnsBindTest, DISABLED_Reordered) {
     string content = FileRead("controller/src/dns/testdata/config_test_2.xml");
     EXPECT_TRUE(parser_.Parse(content));
     task_util::WaitForIdle();
@@ -518,7 +519,8 @@ TEST_F(DnsBindTest, Reordered) {
     }
 }
 
-TEST_F(DnsBindTest, ReorderedExternalReverseResolutionDisabled) {
+// TODO(WINDOWS): JW-1168: NamedConfig is not used in the Agent
+TEST_F(DnsBindTest, DISABLED_ReorderedExternalReverseResolutionDisabled) {
     string content = FileRead("controller/src/dns/testdata/config_test_2_disable_flags.xml");
     EXPECT_TRUE(parser_.Parse(content));
     task_util::WaitForIdle();

--- a/src/ifmap/ifmap_agent_table.cc
+++ b/src/ifmap/ifmap_agent_table.cc
@@ -533,6 +533,7 @@ void IFMapAgentLinkTable::EvalDefLink(IFMapTable::RequestKey *key) {
 
         std::list<DeferredNode> *right_list = right_defmap_it->second;
         std::list<DeferredNode>::iterator right_it, right_list_entry;
+        bool def_list_removed = false;
         for(right_it = right_list->begin(); right_it !=
                 right_list->end(); right_it++) {
 
@@ -542,14 +543,15 @@ void IFMapAgentLinkTable::EvalDefLink(IFMapTable::RequestKey *key) {
 
             if ((*right_it).node_key.id_type == key->id_type &&
                     (*right_it).node_key.id_name == key->id_name) {
-                RemoveDefListEntry(&link_def_map_, right_defmap_it,
-                               &right_it);
+                def_list_removed = RemoveDefListEntry(&link_def_map_,
+                        right_defmap_it,
+                        &right_it);
                 break;
             }
         }
 
         //We should have removed something in the above iteration
-        assert(right_it != right_list->end());
+        assert(def_list_removed || right_it != right_list->end());
 
         //Remove from deferred list before enqueing
         auto_ptr <RequestKey> req_key (new RequestKey);


### PR DESCRIPTION
- Fixed a bug in `IFMapAgentLinkTable` causing access violation in `ifmap_dependency_manager_test`
- Disabled unnecessary DNS bind tests. These tests test `NamedConfig` class which is not used in Agent codebase.